### PR TITLE
Accumulate across traversal

### DIFF
--- a/src/System/Directory/PathWalk.hs
+++ b/src/System/Directory/PathWalk.hs
@@ -2,25 +2,41 @@
 
 module System.Directory.PathWalk
     ( Callback
+    , PureCallback
+    , ForeverCallback
+    , PureForeverCallback
+    , SimpleCallback
+    , SimpleForeverCallback
     , pathWalk
+    , pathWalk_
+    , pureCallback
+    , foreverCallback
+    , pureForeverCallback
+    , simpleCallback
+    , simpleForeverCallback
     , WalkStatus(..)
-    , pathWalkInterruptible
     ) where
 
-import Control.Monad (forM_, filterM)
+import Control.Monad (filterM, foldM)
 import System.Directory (doesDirectoryExist, doesFileExist, getDirectoryContents)
 import System.FilePath ((</>))
-import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT)
 
--- | Called with a directory, list of relative subdirectories, and a
--- list of file names.  If using 'pathWalk', the callback always
--- returns '()'.  If using 'pathWalkInterruptible', it returns whether
--- to continue, prevent recursing further, or stop traversal entirely.
-type Callback a = FilePath -> [FilePath] -> [FilePath] -> IO a
+type GenericCallback a = FilePath -> [FilePath] -> [FilePath] -> a
+-- | Called with a directory, list of relative subdirectories, a list of
+-- file names, and an accumulator.  If using 'pathWalk', the callback
+-- always returns '()'.  If using 'pathWalkInterruptible', it returns
+-- whether to continue, prevent recursing further, or stop traversal
+-- entirely.
+type Callback a = GenericCallback (a -> IO (WalkStatus, a))
+type PureCallback a = GenericCallback (a -> (WalkStatus, a))
+type ForeverCallback a = GenericCallback (a -> IO a)
+type PureForeverCallback a = GenericCallback (a -> a)
+type SimpleCallback = GenericCallback (IO WalkStatus)
+type SimpleForeverCallback = GenericCallback (IO ())
 
--- | 'pathWalk' recursively enumerates the given root directory,
--- calling callback once per directory with the traversed directory
--- name, a list of subdirectories, and a list of files.
+-- | 'pathWalk' recursively enumerates the given root directory, calling
+-- callback once per directory with the traversed directory name, a list
+-- of subdirectories, a list of files, and an accumulator.
 --
 -- The subdirectories and file names are always relative to the root
 -- given.
@@ -31,43 +47,48 @@ type Callback a = FilePath -> [FilePath] -> [FilePath] -> IO a
 --     when ("Test.hs" \`isSuffixOf\` file) $ do
 --       registerTestFile $ dir \</\> file
 -- @
-pathWalk :: FilePath -> Callback () -> IO ()
-pathWalk root callback = do
-  pathWalkInterruptible root $ \dir dirs files -> do
-    callback dir dirs files
-    return Continue
+pathWalk :: FilePath -> Callback a -> a -> IO a
+pathWalk = pathWalkInternal
 
--- | The callback given to 'pathWalkInterruptible' returns a WalkStatus
--- which determines which subsequent directories are traversed.
+-- | Like 'pathWalk' but does not accumulate.
+--
+-- @
+-- pathWalk_ "src" (simpleForeverCallback (\\dir subdirs files -> print files))
+-- @
+pathWalk_ :: FilePath -> Callback () -> IO ()
+pathWalk_ dir c = pathWalk dir c ()
+
+pureCallback :: PureCallback a -> Callback a
+pureCallback c = \dir dirs files initial -> return (c dir dirs files initial)
+
+foreverCallback :: ForeverCallback a -> Callback a
+foreverCallback c = \dir dirs files initial -> c dir dirs files initial >>= \r -> return (Continue, r)
+
+pureForeverCallback :: PureForeverCallback a -> Callback a
+pureForeverCallback c = \dir dirs files initial -> return (Continue, c dir dirs files initial)
+
+simpleCallback :: SimpleCallback -> Callback ()
+simpleCallback c = \dir dirs files _ -> c dir dirs files >>= \s -> return (s, ())
+
+simpleForeverCallback :: SimpleForeverCallback -> Callback ()
+simpleForeverCallback c = \dir dirs files _ -> c dir dirs files >> return (Continue, ())
+
+{--- | The callback given to 'pathWalkInterruptible' returns a WalkStatus-}
+{--- which determines which subsequent directories are traversed.-}
 data WalkStatus
   = Continue -- ^ Continue recursing all subdirectories.
-  | StopRecursing -- ^ Do not traverse deeper.
-  | Stop -- ^ Stop recursing entirely.
+  | Stop -- ^ Stop recursing.
   deriving (Show, Eq)
 
-pathWalkInternal :: FilePath -> Callback WalkStatus -> IO (Maybe ())
-pathWalkInternal root callback = do
+pathWalkInternal :: FilePath -> Callback a -> a -> IO a
+pathWalkInternal root callback initial = do
   names <- getDirectoryContents root
   let properNames = filter (`notElem` [".", ".."]) names
 
   dirs <- filterM (\n -> doesDirectoryExist $ root </> n) properNames
   files <- filterM (\n -> doesFileExist $ root </> n) properNames
 
-  result <- callback root dirs files
+  result <- callback root dirs files initial
   case result of
-    Continue -> do
-      runMaybeT $ do
-        forM_ dirs $ \dir -> do
-          MaybeT $ pathWalkInternal (root </> dir) callback
-    StopRecursing -> do
-      return $ Just ()
-    Stop -> do
-      return Nothing
-
--- | Traverses a directory tree, just like 'pathWalk', except that
--- the callback can determine whether to continue traversal.  See
--- 'WalkStatus'.
-pathWalkInterruptible :: FilePath -> Callback WalkStatus -> IO ()
-pathWalkInterruptible root callback = do
-  _ <- pathWalkInternal root callback
-  return ()
+    (Continue, a) -> foldM (\a' dir -> pathWalkInternal (root </> dir) callback a') a dirs
+    (Stop, a) -> return a


### PR DESCRIPTION
This is a breaking change, but increases the utility of the library quite a bit. It allows accumulating a value across the traversal. For instance, to collect src files:

```
pathWalk "src" (pureForeverCallback (\_ _ files list -> list ++ filter (isSuffixOf ".hs") files)) []
```

While still supporting simple, non-accumulating callbacks:

```
pathWalk_ "src" (simpleForeverCallback (\_ _ files -> print files))
```
